### PR TITLE
require fsevents >1.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "node": ">=6.0.0 <8.0.0"
   },
   "dependencies": {
+    "fsevents": ">1.2.4",
     "body-parser": "^1.18.3",
     "cookie-parser": "~1.4.3",
     "debug": "~3.1.0",


### PR DESCRIPTION
fsevents fails to install due to no binary for current node version (v67) and fsevents 1.2.4, then fails to compile due to ToString deprecation. Forcing fsevents to install @>1.2.4 fixes